### PR TITLE
skip empty secret value

### DIFF
--- a/src/pytest_mask_secrets/plugin.py
+++ b/src/pytest_mask_secrets/plugin.py
@@ -30,7 +30,7 @@ def pytest_runtest_logreport(report):
 
     if "MASK_SECRETS" in os.environ:
         vars_ = os.environ["MASK_SECRETS"].split(",")
-        secrets |= {os.environ[k] for k in vars_ if k in os.environ}
+        secrets |= {os.environ[k] for k in vars_ if os.getenv(k)}
 
     secrets |= _stash[mask_secrets_key]
 


### PR DESCRIPTION
If a user provides a name of a secret that exists in env, but its value is empty, it makes the output flooded with mask (*****). With this change empty secrets are skipped.